### PR TITLE
Use uber-standard-format

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -3,7 +3,7 @@
 var fs = require('fs')
 var minimist = require('minimist')
 var standard = require('../')
-var standardFormat = require('standard-format')
+var standardFormat = require('uber-standard-format')
 var stdin = require('get-stdin')
 
 var argv = minimist(process.argv.slice(2), {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "glob": "^5.0.0",
     "minimist": "^1.1.0",
     "run-parallel": "^1.0.0",
-    "standard-format": "^1.3.3",
+    "uber-standard-format": "^1.3.5",
     "uniq": "^1.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR adds support for uber-standard-format, so you can now do `$ standard --format some-file.js`

cc @raynos @kriskowal @lxe 
