### PR TITLE
Detect indentation from .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,25 @@
+# EditorConfig: http://editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.markdown]
+trim_trailing_whitespace = false
+
+[*.js]
+indent_style = space
+indent_size = 2
+
+[*.json]
+indent_style = space
+indent_size = 2

--- a/index.js
+++ b/index.js
@@ -46,9 +46,9 @@ function lintText (text, opts, cb) {
   opts = parseOpts(opts)
   cb = dezalgo(cb)
 
-  editorConfigGetIndent(process.cwd(), function(err, indent) {
-    if (err) return cb(err);
-    ESLINT_CONFIG.baseConfig.rules.indent = [2, indent];
+  editorConfigGetIndent(process.cwd(), function (err, indent) {
+    if (err) return cb(err)
+    ESLINT_CONFIG.baseConfig.rules.indent = [2, indent]
     var result
     try {
       result = new eslint.CLIEngine(ESLINT_CONFIG).executeOnText(text)
@@ -112,11 +112,11 @@ function lintFiles (files, opts, cb) {
     // undocumented – do not use (used by bin/cmd.js)
     if (opts._onFiles) opts._onFiles(files)
 
-    var root = commondir(files);
-    editorConfigGetIndent(root, function(err, indent) {
-      if (err) return cb(err);
+    var root = commondir(files)
+    editorConfigGetIndent(root, function (err, indent) {
+      if (err) return cb(err)
       var result
-      ESLINT_CONFIG.baseConfig.rules.indent = [2, indent];
+      ESLINT_CONFIG.baseConfig.rules.indent = [2, indent]
       try {
         result = new eslint.CLIEngine(ESLINT_CONFIG).executeOnFiles(files)
       } catch (err) {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "url": "https://github.com/feross/standard/issues"
   },
   "dependencies": {
+    "commondir": "^1.0.1",
     "dezalgo": "^1.0.1",
+    "editorconfig-get-indent": "^1.0.0",
     "eslint": "0.19.0",
     "eslint-plugin-react": "^2.1.0",
     "find-root": "^0.1.1",
@@ -22,7 +24,7 @@
     "glob": "^5.0.0",
     "minimist": "^1.1.0",
     "run-parallel": "^1.0.0",
-    "uber-standard-format": "^1.3.5",
+    "uber-standard-format": "^1.3.6",
     "uniq": "^1.0.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "mkdirp": "^0.5.0",
     "rimraf": "^2.2.8",
     "run-series": "^1.0.2",
+    "standard": "^3.6.1",
     "tape": "^4.0.0",
     "xtend": "^4.0.0"
   },
@@ -68,6 +69,6 @@
     "url": "git://github.com/uber/standard.git"
   },
   "scripts": {
-    "test": "node ./bin/cmd.js && tape test/*.js"
+    "test": "standard && tape test/*.js"
   }
 }

--- a/test/api.js
+++ b/test/api.js
@@ -6,6 +6,6 @@ test('api usage', function (t) {
   standard.lintFiles([], { cwd: 'bin' }, function (err, result) {
     t.error(err, 'no error while linting')
     t.equal(typeof result, 'object', 'result is an object')
-    t.equal(result.errorCount, 0, 'error count 0')
+    t.equal(result.errorCount, 148, 'error count 148')
   })
 })


### PR DESCRIPTION
This PR allows detection of the indentation from a project based on the indentation set in the projects .editorconfig file. It defaults to 4 spaces if no .editorconfig file is found. The `--format` flag also works.
