### PR TITLE
Fixed handling of absolute paths on command line

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,7 +94,8 @@ function lintFiles (files, opts, cb) {
     // flatten nested arrays
     var files = results.reduce(function (files, result) {
       result.forEach(function (file) {
-        files.push(path.join(opts.cwd, file))
+        var f = (file.charAt(0) === '/') ? file : path.join(opts.cwd, file)
+        files.push(f)
       })
       return files
     }, [])

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uber-standard",
   "description": "JavaScript Standard Style",
-  "version": "3.6.2",
+  "version": "3.6.3",
   "author": {
     "name": "Feross Aboukhadijeh",
     "email": "feross@feross.org",


### PR DESCRIPTION
uber/standard currently doesn't handle absolute paths on the command line. this is necessary for proper functioning with `arc lint` which only uses absolute paths. 
