### PR TITLE
Fix json/checkstyle reporter when no errors

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -105,7 +105,7 @@ if (argv.stdin) {
 
 function onResult (err, result) {
   if (err) return onError(err)
-  if (result.errorCount === 0) process.exit(0)
+  if (result.errorCount === 0) return exit(0)
 
   console.error(
     'Error: Use Uber JavaScript Standard Style ' +
@@ -122,12 +122,16 @@ function onResult (err, result) {
     })
   })
 
+  exit(1)
+}
+
+function exit(code) {
   if (reporter) {
     reporter.end()
   }
 
   process.on('exit', function () {
-    process.exit(1)
+    process.exit(code)
   })
 }
 

--- a/index.js
+++ b/index.js
@@ -113,6 +113,10 @@ function lintFiles (files, opts, cb) {
     // undocumented – do not use (used by bin/cmd.js)
     if (opts._onFiles) opts._onFiles(files)
 
+    if (files.length === 0) {
+      return cb(null, {errorCount: 0})
+    }
+
     var root = commondir(files)
     editorConfigGetIndent(root, function (err, indent) {
       if (err) return cb(err)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uber-standard",
   "description": "JavaScript Standard Style",
-  "version": "3.6.3",
+  "version": "3.6.4",
   "author": {
     "name": "Feross Aboukhadijeh",
     "email": "feross@feross.org",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "glob": "^5.0.0",
     "minimist": "^1.1.0",
     "run-parallel": "^1.0.0",
-    "standard-reporter": "^1.0.4",
+    "standard-reporter": "^1.0.5",
     "uber-standard-format": "^1.3.6",
     "uniq": "^1.0.1"
   },


### PR DESCRIPTION
This makes sure that an "empty" json or xml object is printed for the json or checkstyle reporters.
