### PR TITLE
Bump max params to 5

### DIFF
--- a/rc/.eslintrc.json
+++ b/rc/.eslintrc.json
@@ -207,7 +207,7 @@
         ],
         "max-params": [
             2,
-            4
+            5
         ],
         "max-statements": [
             2,


### PR DESCRIPTION
@malandrew @Raynos 

This is a proposal to bump max-params to 5.

The tchannel handler functions take 5 parameters:

``` javascript
module.exports = function doSomething(options, req, head, body, callback) {
};
```

Disabling this for every handler is a pain. If we're all moving towards tchannel, it seems like a good reason to bump this to 5.
