### PR TITLE
Add ES6 linking support

### DIFF
--- a/rc/.eslintrc.json
+++ b/rc/.eslintrc.json
@@ -1,10 +1,32 @@
 {
+    "ecmaFeatures": {
+        "arrowFunctions": true,
+        "blockBindings": true,
+        "regexUFlag": true,
+        "regexYFlag": true,
+        "templateStrings": true,
+        "binaryLiterals": true,
+        "octalLiterals": true,
+        "unicodeCodePointEscapes": true,
+        "superInFunctions": true,
+        "defaultParams": true,
+        "restParams": true,
+        "forOf": true,
+        "objectLiteralComputedProperties": true,
+        "objectLiteralShorthandMethods": true,
+        "objectLiteralShorthandProperties": true,
+        "objectLiteralDuplicateProperties": true,
+        "generators": true,
+        "destructuring": true,
+        "classes": true
+    },
     "env": {
         "browser": false,
         "node": false,
         "amd": false,
         "mocha": false,
-        "jasmine": false
+        "jasmine": false,
+        "es6": false
     },
     "globals": {
         "__dirname": false,


### PR DESCRIPTION
Manually move over the config from eslint environments so that we have full control.
