### PR TITLE
Upgrade eslint; Add `--es6` flag; Add `--line-length` flag

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -22,8 +22,15 @@ var argv = minimist(process.argv.slice(2), {
     'help',
     'stdin',
     'verbose',
-    'version'
-  ]
+    'version',
+    'es6'
+  ],
+  string: [
+    'line-length'
+  ],
+  default: {
+    'line-length': '80'
+  }
 })
 
 // running `standard -` is equivalent to `standard --stdin`
@@ -76,6 +83,12 @@ if (argv.reporter) {
   })
 }
 
+var lintOpts = {}
+if (argv.es6)
+  lintOpts.es6 = true
+if (argv['line-length'])
+  lintOpts['line-length'] = parseInt(argv['line-length'], 10)
+
 if (argv.stdin) {
   editorConfigGetIndent(process.cwd(), function (err, indent) {
     if (err) return onError(err)
@@ -84,11 +97,10 @@ if (argv.stdin) {
         text = standardFormat.transform(text, indent)
         process.stdout.write(text)
       }
-      standard.lintText(text, onResult)
+      standard.lintText(text, lintOpts, onResult)
     })
   })
 } else {
-  var lintOpts = {}
   if (argv.format) {
     lintOpts._onFiles = function (files) {
       editorConfigGetIndent(commondir(files), function (err, indent) {

--- a/package.json
+++ b/package.json
@@ -16,10 +16,11 @@
     "url": "https://github.com/feross/standard/issues"
   },
   "dependencies": {
+    "clone-deep": "^0.1.1",
     "commondir": "^1.0.1",
     "dezalgo": "^1.0.1",
     "editorconfig-get-indent": "^1.0.0",
-    "eslint": "0.23.0",
+    "eslint": "https://github.com/eslint/eslint.git#80826e1f58b09bcce9490141896f18138022ecd3",
     "eslint-plugin-react": "^2.1.0",
     "find-root": "^0.1.1",
     "get-stdin": "^4.0.1",

--- a/rc/.eslintrc.es6.json
+++ b/rc/.eslintrc.es6.json
@@ -1,0 +1,31 @@
+{
+    "rules": {
+        "newline-after-var": [
+            2,
+            "always"
+        ],
+        "prefer-const": 2,
+        "no-var": 2
+    },
+    "ecmaFeatures": {
+        "arrowFunctions": true,
+        "blockBindings": true,
+        "regexUFlag": true,
+        "regexYFlag": true,
+        "templateStrings": true,
+        "binaryLiterals": true,
+        "octalLiterals": true,
+        "unicodeCodePointEscapes": true,
+        "superInFunctions": true,
+        "defaultParams": true,
+        "restParams": true,
+        "forOf": true,
+        "objectLiteralComputedProperties": true,
+        "objectLiteralShorthandMethods": true,
+        "objectLiteralShorthandProperties": true,
+        "objectLiteralDuplicateProperties": true,
+        "generators": true,
+        "destructuring": true,
+        "classes": true
+    }
+}

--- a/rc/.eslintrc.json
+++ b/rc/.eslintrc.json
@@ -4,7 +4,8 @@
         "node": false,
         "amd": false,
         "mocha": false,
-        "jasmine": false
+        "jasmine": false,
+        "es6": false
     },
     "globals": {
         "__dirname": false,
@@ -22,14 +23,18 @@
         "no-cond-assign": 2,
         "no-console": 2,
         "no-constant-condition": 2,
+        "no-continue": 0,
         "no-control-regex": 2,
         "no-debugger": 2,
         "no-delete-var": 2,
         "no-div-regex": 0,
         "no-dupe-keys": 2,
+        "no-dupe-args": 2,
+        "no-duplicate-case": 2,
         "no-else-return": 0,
         "no-empty": 2,
         "no-empty-class": 2,
+        "no-empty-character-class": 2,
         "no-empty-label": 2,
         "no-eq-null": 0,
         "no-eval": 2,
@@ -65,6 +70,10 @@
             2,
             false
         ],
+        "linebreak-style": [
+            2,
+            "unix"
+        ],
         "no-multi-spaces": 2,
         "no-multi-str": 2,
         "no-multiple-empty-lines": [
@@ -84,6 +93,7 @@
         "no-obj-calls": 2,
         "no-octal": 2,
         "no-octal-escape": 2,
+        "no-param-reassign": 0,
         "no-path-concat": 2,
         "no-plusplus": 0,
         "no-process-env": 2,
@@ -105,10 +115,13 @@
         "no-sync": 0,
         "no-ternary": 0,
         "no-trailing-spaces": 2,
+        "no-this-before-super": 2,
+        "no-throw-literal": 2,
         "no-undef": 2,
         "no-undef-init": 2,
         "no-undefined": 0,
         "no-underscore-dangle": 0,
+        "no-unneeded-ternary": 2,
         "no-unreachable": 2,
         "no-unused-expressions": 2,
         "no-unused-vars": [
@@ -123,6 +136,8 @@
             "nofunc"
         ],
         "no-void": 0,
+        "no-var": 0,
+        "prefer-const": 0,
         "no-warning-comments": [
             0,
             {
@@ -136,12 +151,26 @@
         ],
         "no-with": 2,
         "no-wrap-func": 2,
+
+        "array-bracket-spacing": [
+            2,
+            "never"
+        ],
+        "accessor-pairs": [
+            2, {
+                "getWithoutSet": true
+            }
+        ],
         "block-scoped-var": 0,
         "brace-style": [
             2,
             "1tbs"
         ],
         "camelcase": 2,
+        "comma-dangle": [
+            2,
+            "never"
+        ],
         "comma-spacing": [
             2,
             {
@@ -157,6 +186,10 @@
             2,
             11
         ],
+        "computed-property-spacing": [
+            2,
+            "never"
+        ],
         "consistent-return": 2,
         "consistent-this": [
             2,
@@ -167,6 +200,10 @@
             "all"
         ],
         "default-case": 2,
+        "dot-location": [
+            2,
+            "property"
+        ],
         "dot-notation": 2,
         "eol-last": 2,
         "eqeqeq": 2,
@@ -174,6 +211,10 @@
         "func-style": [
             0,
             "declaration"
+        ],
+        "generator-star-spacing": [
+            2,
+            "after"
         ],
         "global-strict": [
             2,
@@ -190,6 +231,17 @@
             {
                 "beforeColon": false,
                 "afterColon": true
+            }
+        ],
+        "lines-around-comment": [
+            0,
+            {
+              "beforeBlockComment": true,
+              "afterBlockComment": false,
+              "beforeLineComment": false,
+              "afterLineComment": false,
+              "allowBlockStart": false,
+              "allowBlockEnd": false
             }
         ],
         "max-depth": [
@@ -221,7 +273,19 @@
             }
         ],
         "new-parens": 2,
-        "one-var": [2, "never"],
+        "newline-after-var": 0,
+        "object-curly-spacing": [
+            2,
+            "never"
+        ],
+        "object-shorthand": 0,
+        "one-var": [
+            2,
+            {
+                "uninitialized": "always",
+                "initialized": "never"
+            }
+        ],
         "operator-assignment": [
             0,
             "always"
@@ -234,6 +298,13 @@
         ],
         "radix": 2,
         "semi": 2,
+        "semi-spacing": [
+            2,
+            {
+                "before": false,
+                "after": true
+            }
+        ],
         "sort-vars": 0,
         "space-after-function-name": [
             2,
@@ -246,6 +317,10 @@
         "space-before-blocks": [
             2,
             "always"
+        ],
+        "space-before-function-paren": [
+            2,
+            "never"
         ],
         "space-in-brackets": [
             2,
@@ -264,6 +339,7 @@
                 "nonwords": false
             }
         ],
+        "spaced-comment": 0,
         "spaced-line-comment": [
             2,
             "always"
@@ -285,5 +361,26 @@
             2,
             "never"
         ]
+    },
+    "ecmaFeatures": {
+        "arrowFunctions": true,
+        "blockBindings": true,
+        "regexUFlag": true,
+        "regexYFlag": true,
+        "templateStrings": true,
+        "binaryLiterals": true,
+        "octalLiterals": true,
+        "unicodeCodePointEscapes": true,
+        "superInFunctions": true,
+        "defaultParams": true,
+        "restParams": true,
+        "forOf": true,
+        "objectLiteralComputedProperties": true,
+        "objectLiteralShorthandMethods": true,
+        "objectLiteralShorthandProperties": true,
+        "objectLiteralDuplicateProperties": true,
+        "generators": true,
+        "destructuring": true,
+        "classes": true
     }
 }


### PR DESCRIPTION
This pull request upgrades the version of eslint used and adds an `--es6` flag (off by default) and a `--line-length` flag that you can use to set the line length.

Once everything is good, I'll merge this in as major version change.

The only new rule I was uncertain about is the `no-continue`, which I think would be good to enable. 
https://github.com/eslint/eslint/blob/master/docs/rules/no-continue.md

I also was curious if anyone had any opinions on turning on the object-shorthand rule for the `--es6` flag?
https://github.com/eslint/eslint/blob/master/docs/rules/object-shorthand.md

@raynos @lxe @mlmorg
