### PR TITLE
Upgrade eslint; Add `--es6` flag; Add `--line-length` flag

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -46,7 +46,7 @@ if (argv.help) {
   Usage:
       standard <flags> [FILES...]
 
-      If FILES is omitted, then all JavaScript source files (*.js, *.jsx) in the current
+      If FILES is omitted, then all JavaScript source files (*.js) in the current
       working directory are checked, recursively.
 
       Certain paths (node_modules/, .git/, coverage/, *.min.js, bundle.js) are

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -18,6 +18,7 @@ var argv = minimist(process.argv.slice(2), {
     verbose: 'v'
   },
   boolean: [
+    'es6',
     'format',
     'help',
     'stdin',
@@ -85,6 +86,8 @@ if (argv.reporter) {
 var lintOpts = {}
 if (argv['line-length'])
   lintOpts['line-length'] = parseInt(argv['line-length'], 10)
+if (argv.es6)
+  lintOpts.es6 = true
 
 if (argv.stdin) {
   editorConfigGetIndent(process.cwd(), function (err, indent) {

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -23,7 +23,13 @@ var argv = minimist(process.argv.slice(2), {
     'stdin',
     'verbose',
     'version'
-  ]
+  ],
+  string: [
+    'line-length'
+  ],
+  default: {
+    'line-length': '80'
+  }
 })
 
 // running `standard -` is equivalent to `standard --stdin`
@@ -76,6 +82,10 @@ if (argv.reporter) {
   })
 }
 
+var lintOpts = {}
+if (argv['line-length'])
+  lintOpts['line-length'] = parseInt(argv['line-length'], 10)
+
 if (argv.stdin) {
   editorConfigGetIndent(process.cwd(), function (err, indent) {
     if (err) return onError(err)
@@ -84,11 +94,10 @@ if (argv.stdin) {
         text = standardFormat.transform(text, indent)
         process.stdout.write(text)
       }
-      standard.lintText(text, onResult)
+      standard.lintText(text, lintOpts, onResult)
     })
   })
 } else {
-  var lintOpts = {}
   if (argv.format) {
     lintOpts._onFiles = function (files) {
       editorConfigGetIndent(commondir(files), function (err, indent) {

--- a/index.js
+++ b/index.js
@@ -14,8 +14,7 @@ var uniq = require('uniq')
 var cloneDeep = require('clone-deep')
 
 var DEFAULT_PATTERNS = [
-  '**/*.js',
-  '**/*.jsx'
+  '**/*.js'
 ]
 
 var DEFAULT_IGNORE_PATTERNS = [

--- a/index.js
+++ b/index.js
@@ -24,6 +24,8 @@ var DEFAULT_IGNORE_PATTERNS = [
   '**/bundle.js'
 ]
 
+var es6Config = require(path.join(__dirname, 'rc', '.eslintrc.es6.json'))
+
 var ESLINT_CONFIG = {
   baseConfig: require(path.join(__dirname, 'rc', '.eslintrc.json')),
   useEslintrc: true
@@ -36,6 +38,14 @@ function configure(opts) {
 
   if (opts['line-length']) {
     config.baseConfig.rules['max-len'] = [2, opts['line-length'], 4]
+  }
+
+  if (opts.es6) {
+    config.baseConfig.ecmaFeatures = es6Config.ecmaFeatures
+
+    Object.keys(es6Config.rules).forEach(function onRule(ruleName) {
+      config.baseConfig.rules[ruleName] = es6Config.rules[ruleName]
+    })
   }
 
   return config;

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ var glob = require('glob')
 var parallel = require('run-parallel')
 var path = require('path')
 var uniq = require('uniq')
+var cloneDeep = require('clone-deep')
 
 var DEFAULT_PATTERNS = [
   '**/*.js',
@@ -27,6 +28,18 @@ var DEFAULT_IGNORE_PATTERNS = [
 var ESLINT_CONFIG = {
   baseConfig: require(path.join(__dirname, 'rc', '.eslintrc.json')),
   useEslintrc: true
+}
+
+function configure(opts) {
+  var config = cloneDeep(ESLINT_CONFIG)
+
+  config.baseConfig.rules.indent = [2, opts.indent]
+
+  if (opts['line-length']) {
+    config.baseConfig.rules['max-len'] = [2, opts['line-length'], 4]
+  }
+
+  return config;
 }
 
 /**
@@ -48,10 +61,10 @@ function lintText (text, opts, cb) {
 
   editorConfigGetIndent(process.cwd(), function (err, indent) {
     if (err) return cb(err)
-    ESLINT_CONFIG.baseConfig.rules.indent = [2, indent]
+    opts.indent = indent
     var result
     try {
-      result = new eslint.CLIEngine(ESLINT_CONFIG).executeOnText(text)
+      result = new eslint.CLIEngine(configure(opts)).executeOnText(text)
     } catch (err) {
       return cb(err)
     }
@@ -121,9 +134,9 @@ function lintFiles (files, opts, cb) {
     editorConfigGetIndent(root, function (err, indent) {
       if (err) return cb(err)
       var result
-      ESLINT_CONFIG.baseConfig.rules.indent = [2, indent]
+      opts.indent = indent
       try {
-        result = new eslint.CLIEngine(ESLINT_CONFIG).executeOnFiles(files)
+        result = new eslint.CLIEngine(configure(opts)).executeOnFiles(files)
       } catch (err) {
         return cb(err)
       }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "url": "https://github.com/feross/standard/issues"
   },
   "dependencies": {
+    "clone-deep": "^0.1.1",
     "commondir": "^1.0.1",
     "dezalgo": "^1.0.1",
     "editorconfig-get-indent": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "commondir": "^1.0.1",
     "dezalgo": "^1.0.1",
     "editorconfig-get-indent": "^1.0.0",
-    "eslint": "0.23.0",
+    "eslint": "git+https://github.com/eslint/eslint.git#80826e1f58b09bcce9490141896f18138022ecd3",
     "eslint-plugin-react": "^2.1.0",
     "find-root": "^0.1.1",
     "get-stdin": "^4.0.1",

--- a/rc/.eslintrc.es6.json
+++ b/rc/.eslintrc.es6.json
@@ -1,0 +1,31 @@
+{
+    "rules": {
+        "newline-after-var": [
+            2,
+            "always"
+        ],
+        "prefer-const": 2,
+        "no-var": 2
+    },
+    "ecmaFeatures": {
+        "arrowFunctions": true,
+        "blockBindings": true,
+        "regexUFlag": true,
+        "regexYFlag": true,
+        "templateStrings": true,
+        "binaryLiterals": true,
+        "octalLiterals": true,
+        "unicodeCodePointEscapes": true,
+        "superInFunctions": true,
+        "defaultParams": true,
+        "restParams": true,
+        "forOf": true,
+        "objectLiteralComputedProperties": true,
+        "objectLiteralShorthandMethods": true,
+        "objectLiteralShorthandProperties": true,
+        "objectLiteralDuplicateProperties": true,
+        "generators": true,
+        "destructuring": true,
+        "classes": true
+    }
+}

--- a/rc/.eslintrc.json
+++ b/rc/.eslintrc.json
@@ -286,7 +286,6 @@
                 "initialized": "never"
             }
         ],
-        "one-var": [2, "never"],
         "operator-assignment": [
             0,
             "always"

--- a/rc/.eslintrc.json
+++ b/rc/.eslintrc.json
@@ -4,7 +4,8 @@
         "node": false,
         "amd": false,
         "mocha": false,
-        "jasmine": false
+        "jasmine": false,
+        "es6": false
     },
     "globals": {
         "__dirname": false,
@@ -22,14 +23,18 @@
         "no-cond-assign": 2,
         "no-console": 2,
         "no-constant-condition": 2,
+        "no-continue": 0,
         "no-control-regex": 2,
         "no-debugger": 2,
         "no-delete-var": 2,
         "no-div-regex": 0,
         "no-dupe-keys": 2,
+        "no-dupe-args": 2,
+        "no-duplicate-case": 2,
         "no-else-return": 0,
         "no-empty": 2,
         "no-empty-class": 2,
+        "no-empty-character-class": 2,
         "no-empty-label": 2,
         "no-eq-null": 0,
         "no-eval": 2,
@@ -65,6 +70,10 @@
             2,
             false
         ],
+        "linebreak-style": [
+            2,
+            "unix"
+        ],
         "no-multi-spaces": 2,
         "no-multi-str": 2,
         "no-multiple-empty-lines": [
@@ -84,6 +93,7 @@
         "no-obj-calls": 2,
         "no-octal": 2,
         "no-octal-escape": 2,
+        "no-param-reassign": 0,
         "no-path-concat": 2,
         "no-plusplus": 0,
         "no-process-env": 2,
@@ -105,10 +115,13 @@
         "no-sync": 0,
         "no-ternary": 0,
         "no-trailing-spaces": 2,
+        "no-this-before-super": 2,
+        "no-throw-literal": 2,
         "no-undef": 2,
         "no-undef-init": 2,
         "no-undefined": 0,
         "no-underscore-dangle": 0,
+        "no-unneeded-ternary": 2,
         "no-unreachable": 2,
         "no-unused-expressions": 2,
         "no-unused-vars": [
@@ -122,7 +135,9 @@
             2,
             "nofunc"
         ],
-        "no-void": 0,
+        "no-void": 2,
+        "no-var": 0,
+        "prefer-const": 0,
         "no-warning-comments": [
             0,
             {
@@ -136,12 +151,26 @@
         ],
         "no-with": 2,
         "no-wrap-func": 2,
+
+        "array-bracket-spacing": [
+            2,
+            "never"
+        ],
+        "accessor-pairs": [
+            2, {
+                "getWithoutSet": true
+            }
+        ],
         "block-scoped-var": 0,
         "brace-style": [
             2,
             "1tbs"
         ],
         "camelcase": 2,
+        "comma-dangle": [
+            2,
+            "never"
+        ],
         "comma-spacing": [
             2,
             {
@@ -157,6 +186,10 @@
             2,
             11
         ],
+        "computed-property-spacing": [
+            2,
+            "never"
+        ],
         "consistent-return": 2,
         "consistent-this": [
             2,
@@ -167,6 +200,10 @@
             "all"
         ],
         "default-case": 2,
+        "dot-location": [
+            2,
+            "property"
+        ],
         "dot-notation": 2,
         "eol-last": 2,
         "eqeqeq": 2,
@@ -174,6 +211,10 @@
         "func-style": [
             0,
             "declaration"
+        ],
+        "generator-star-spacing": [
+            2,
+            "after"
         ],
         "global-strict": [
             2,
@@ -190,6 +231,17 @@
             {
                 "beforeColon": false,
                 "afterColon": true
+            }
+        ],
+        "lines-around-comment": [
+            0,
+            {
+              "beforeBlockComment": true,
+              "afterBlockComment": false,
+              "beforeLineComment": false,
+              "afterLineComment": false,
+              "allowBlockStart": false,
+              "allowBlockEnd": false
             }
         ],
         "max-depth": [
@@ -221,6 +273,19 @@
             }
         ],
         "new-parens": 2,
+        "newline-after-var": 0,
+        "object-curly-spacing": [
+            2,
+            "never"
+        ],
+        "object-shorthand": 0,
+        "one-var": [
+            2,
+            {
+                "uninitialized": "always",
+                "initialized": "never"
+            }
+        ],
         "one-var": [2, "never"],
         "operator-assignment": [
             0,
@@ -234,6 +299,13 @@
         ],
         "radix": 2,
         "semi": 2,
+        "semi-spacing": [
+            2,
+            {
+                "before": false,
+                "after": true
+            }
+        ],
         "sort-vars": 0,
         "space-after-function-name": [
             2,
@@ -246,6 +318,10 @@
         "space-before-blocks": [
             2,
             "always"
+        ],
+        "space-before-function-paren": [
+            2,
+            "never"
         ],
         "space-in-brackets": [
             2,
@@ -264,6 +340,7 @@
                 "nonwords": false
             }
         ],
+        "spaced-comment": 0,
         "spaced-line-comment": [
             2,
             "always"


### PR DESCRIPTION
This pull request upgrades the version of eslint used and adds an --es6 flag (off by default) and a --line-length flag that you can use to set the line length.

Once everything is good, I'll merge this in as major version change.

The only new rule I was uncertain about is the no-continue, which I think would be good to enable. 
https://github.com/eslint/eslint/blob/master/docs/rules/no-continue.md

I also was curious if anyone had any opinions on turning on the object-shorthand rule for the --es6 flag?
https://github.com/eslint/eslint/blob/master/docs/rules/object-shorthand.md

@raynos @lxe @mlmorg @freeqaz 

(This is the same pull request as previously but with separate commits for all the changes)
