### PR TITLE
rc: update default max-statements to 25

### DIFF
--- a/rc/.eslintrc.json
+++ b/rc/.eslintrc.json
@@ -211,7 +211,7 @@
         ],
         "max-statements": [
             2,
-            15
+            25
         ],
         "new-cap": [
             2,


### PR DESCRIPTION
I add an overwrite rule on almost every project to bump this
to 25.

I've found 25 to work a lot better and every time i get this
warning i truly feel like i've got a too big method.

However the 15 limit is really low and easy to hit into.

r: @Matt-Esch @malandrew @jcorbin
