### PR TITLE
Support line-length flag

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -23,7 +23,13 @@ var argv = minimist(process.argv.slice(2), {
     'stdin',
     'verbose',
     'version'
-  ]
+  ],
+  string: [
+    'line-length'
+  ],
+  default: {
+    'line-length': '80'
+  }
 })
 
 // running `standard -` is equivalent to `standard --stdin`
@@ -76,6 +82,10 @@ if (argv.reporter) {
   })
 }
 
+var lintOpts = {}
+if (argv['line-length'])
+  lintOpts['line-length'] = parseInt(argv['line-length'], 10)
+
 if (argv.stdin) {
   editorConfigGetIndent(process.cwd(), function (err, indent) {
     if (err) return onError(err)
@@ -84,11 +94,10 @@ if (argv.stdin) {
         text = standardFormat.transform(text, indent)
         process.stdout.write(text)
       }
-      standard.lintText(text, onResult)
+      standard.lintText(text, lintOpts, onResult)
     })
   })
 } else {
-  var lintOpts = {}
   if (argv.format) {
     lintOpts._onFiles = function (files) {
       editorConfigGetIndent(commondir(files), function (err, indent) {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "url": "https://github.com/feross/standard/issues"
   },
   "dependencies": {
+    "clone-deep": "^0.1.1",
     "commondir": "^1.0.1",
     "dezalgo": "^1.0.1",
     "editorconfig-get-indent": "^1.0.0",


### PR DESCRIPTION
This adds a `--line-length` flag like lint-trap has.

cc: @Raynos @jcorbin
