### PR TITLE
Supported file fix

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -40,7 +40,7 @@ if (argv.help) {
   Usage:
       standard <flags> [FILES...]
 
-      If FILES is omitted, then all JavaScript source files (*.js, *.jsx) in the current
+      If FILES is omitted, then all JavaScript source files (*.js) in the current
       working directory are checked, recursively.
 
       Certain paths (node_modules/, .git/, coverage/, *.min.js, bundle.js) are

--- a/index.js
+++ b/index.js
@@ -13,8 +13,7 @@ var path = require('path')
 var uniq = require('uniq')
 
 var DEFAULT_PATTERNS = [
-  '**/*.js',
-  '**/*.jsx'
+  '**/*.js'
 ]
 
 var DEFAULT_IGNORE_PATTERNS = [


### PR DESCRIPTION
Lint only files that end in *.js.

cc: @Raynos @jcorbin 
