### PR TITLE
Experimental ES6 Support

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -18,6 +18,7 @@ var argv = minimist(process.argv.slice(2), {
     verbose: 'v'
   },
   boolean: [
+    'es6',
     'format',
     'help',
     'stdin',
@@ -85,6 +86,8 @@ if (argv.reporter) {
 var lintOpts = {}
 if (argv['line-length'])
   lintOpts['line-length'] = parseInt(argv['line-length'], 10)
+if (argv.es6)
+  lintOpts.es6 = true
 
 if (argv.stdin) {
   editorConfigGetIndent(process.cwd(), function (err, indent) {

--- a/index.js
+++ b/index.js
@@ -24,6 +24,8 @@ var DEFAULT_IGNORE_PATTERNS = [
   '**/bundle.js'
 ]
 
+var es6Config = require(path.join(__dirname, 'rc', '.eslintrc.es6.json'))
+
 var ESLINT_CONFIG = {
   baseConfig: require(path.join(__dirname, 'rc', '.eslintrc.json')),
   useEslintrc: true,
@@ -37,6 +39,14 @@ function configure(opts) {
 
   if (opts['line-length']) {
     config.baseConfig.rules['max-len'] = [2, opts['line-length'], 4]
+  }
+
+  if (opts.es6) {
+    config.baseConfig.ecmaFeatures = es6Config.ecmaFeatures
+
+    Object.keys(es6Config.rules).forEach(function onRule(ruleName) {
+      config.baseConfig.rules[ruleName] = es6Config.rules[ruleName]
+    })
   }
 
   return config;

--- a/rc/.eslintrc.es6.json
+++ b/rc/.eslintrc.es6.json
@@ -22,6 +22,12 @@
             2,
             "never"
         ],
+        "accessor-pairs": [
+            2,
+            {
+                "getWithoutSet": true
+            }
+        ],
         "block-scoped-var": 2,
         "computed-property-spacing": [
             2,
@@ -69,7 +75,7 @@
         ],
         "object-shorthand": [
             2,
-            "never"
+            "always"
         ],
         "operator-linebreak": [
             2,

--- a/rc/.eslintrc.es6.json
+++ b/rc/.eslintrc.es6.json
@@ -1,0 +1,31 @@
+{
+    "rules": {
+        "newline-after-var": [
+            2,
+            "always"
+        ],
+        "prefer-const": 2,
+        "no-var": 2
+    },
+    "ecmaFeatures": {
+        "arrowFunctions": true,
+        "blockBindings": true,
+        "regexUFlag": true,
+        "regexYFlag": true,
+        "templateStrings": true,
+        "binaryLiterals": true,
+        "octalLiterals": true,
+        "unicodeCodePointEscapes": true,
+        "superInFunctions": true,
+        "defaultParams": true,
+        "restParams": true,
+        "forOf": true,
+        "objectLiteralComputedProperties": true,
+        "objectLiteralShorthandMethods": true,
+        "objectLiteralShorthandProperties": true,
+        "objectLiteralDuplicateProperties": true,
+        "generators": true,
+        "destructuring": true,
+        "classes": true
+    }
+}

--- a/rc/.eslintrc.es6.json
+++ b/rc/.eslintrc.es6.json
@@ -1,11 +1,104 @@
 {
     "rules": {
+        "no-catch-shadow": 2,
+        "no-continue": 2,
+        "no-div-regex": 2,
+        "no-else-return": 2,
+        "no-eq-null": 2,
+        "no-extra-parens": 2,
+        "no-inline-comments": 2,
+        "no-mixed-requires": 2,
+        "no-this-before-super": 2,
+        "no-throw-literal": 2,
+        "no-unexpected-multiline": 2,
+        "no-unneeded-ternary": 2,
         "newline-after-var": [
             2,
             "always"
         ],
+        "no-var": 2,
         "prefer-const": 2,
-        "no-var": 2
+        "array-bracket-spacing": [
+            2,
+            "never"
+        ],
+        "block-scoped-var": 2,
+        "computed-property-spacing": [
+            2,
+            "never"
+        ],
+        "constructor-super": 0,
+        "dot-location": [
+            2,
+            "property"
+        ],
+        "func-style": [
+            2,
+            "declaration"
+        ],
+        "generator-star-spacing": [
+            2,
+            {
+                "before": false,
+                "after": true
+            }
+        ],
+        "lines-around-comment": [
+            0,
+            {
+                "beforeBlockComment": true,
+                "afterBlockComment": false,
+                "beforeLineComment": false,
+                "afterLineComment": false,
+                "allowBlockStart": true,
+                "allowBlockEnd": true
+            }
+        ],
+        "max-depth": [
+            2,
+            3
+        ],
+        "max-statements": [
+            2,
+            15
+        ],
+        "newline-after-var": 2,
+        "object-curly-spacing": [
+            2,
+            "never"
+        ],
+        "object-shorthand": [
+            2,
+            "never"
+        ],
+        "operator-linebreak": [
+            2,
+            "before"
+        ],
+        "quote-props": [
+            2,
+            "as-needed"
+        ],
+        "sort-vars": 2,
+        "space-before-function-paren": [
+            2,
+            "never"
+        ],
+        "spaced-comment": [
+            2,
+            [
+                "never",
+                {
+                  "exceptions":[
+                      "-",
+                      "=",
+                      "+",
+                      "*"
+                  ]
+                }
+            ]
+        ],
+        "wrap-regex": 2
     },
     "ecmaFeatures": {
         "arrowFunctions": true,


### PR DESCRIPTION
This diff adds experimental ES6 support. 

Since ES6 is for all intents and purposes a different language (until all runtimes, frontend and backend, support it), is experimental and has not yet been supported yet at uber until now, es6 mode will be used as a testing ground for trying out rules that may be backported into es5 mode if they provide utility in removing footguns and making code more consistent.

i.e. if you want greater rule stability, choose es5 mode. If you're open to try out ES6, you're also opting in to being tolerant of trying out new rules to see if they provide greater code consistency between teams.

In an effort to ship ES6 mode to those who have been waiting, this PR will remain open for 24 hours after the first LGTM. Please look over the proposed rules and raise concerns now.

The rules specific to ES6 that I am curious to get people's opinion on are:
- `object-shorthand` mode - There are cases where it makes things more readable and cases where it makes things less readable.
- `accessor-pairs` mode - I didn't turn this one are, but should we? This one has configuration options.

Rules specific to ES6 mode are:
- `no-var` (what's the point in having `let` and `const` if you aren't going to use them over `var`)
- `prefer-const`
- `generator-star-spacing`
- `accessor-pairs`
- `constructor-super`
- `no-this-before-super`

Rules that are likely candidates to be ported to ES5 mode for the next major release are:
- `no-catch-shadow` (probably a noop since there was already a no-shadow rule)
- `no-continue`
- `no-div-regex`
- `no-else-return`
- `no-eq-null` (probably a noop since we already enforce strict equality)
- `no-extra-parens`
- `no-inline-comments` (was already in lint-trap)
- `no-mixed-requires` (probably a noop since we do one var per line)
- `no-throw-literal` (long overdue, you should always generate an error object with a stack trace)
- `no-unexpected-multiline`
- `no-unneeded-ternary`
- `array-bracket-spacing` (was already in lint trap)
- `block-scoped-var`
- `computed-property-spacing`
- `dot-location`
- `func-style` - this rule I am unsure about and want to try out because it seems like this isn't a 100% rule and it looks like it allows function expressions in many cases where you really only want a function expression (like assigning a function expression to a property on `this` in the constructor or assigning prototype props to function expressions). Because of this, I want to see how this actually works in practice. 
- `newline-after-var`
- `object-curly-spacing` (was already in lint-trap)
- `operator-linebreak`
- `quote-props` - This one is turned on with the configuration "as-needed". I'm curious to get feedback on whether or not this is useful or problematic. Hard to tell without seeing how it actually works in the wild.
- `sort-vars` - Given that we require one var per line, this one probably is a noop. However there is another rule, `one-var` which has an "uninitialized" and "initialized" option which is interesting that would make this rule relevant.
- `space-before-function-paren` - this one should be a noop because I believe this is already enforced by some other rule we already have turned on. This was already rule in lint-trap.
- `spaced-comment` - I need feedback from people on this one when it is used in practice. Most likely this is a useful rule, but will need to have the "exceptions" and "markers" options modified based on cases where it may not work.

Rules that remain turned off for both ES5 and ES6 mode:
- `no-bitwise`
- `no-nested-ternary`
- `no-param-reassign`
- `no-plusplus`
- `no-reserved-keys`
- `no-sync`
- `no-ternary`
- `no-undefined`
- `no-void`
- `lines-around-comment` - completely off, but I want others to look at whether some of the configurable options on this rule could be valuable.
- `padded-blocks`
- `vars-on-top`

The `no-restricted-modules` mode will be evaluated separately for both environments and will be added in in a separate pull request.

All the rules can be found here: https://github.com/eslint/eslint/tree/master/docs/rules

FWIW, I want to eventually look into getting "custom env" support in eslint so that these can be moved to something you could turn on and off per file with an inline directive like: `/*eslint-env es6*/`, but for now you turn this on with the `--es6` command line flag.

cc: @raynos @lxe @johnmegahan @rtsao @mlmorg @marthakelly @jcorbin @freeqaz @vicapow @philogb @superbeefy @mishabosin @addisonedwardlee @kenzanboo @collenjones @cain-uber @partriv @shaohua @yuanzong @Amazeotron @danielheller @Jeloi @jschao-uber @MarkReeder @noamlerner @Matt-Esch @rajeshsegu @rhobot @sh1mmer @thegleb @kriskowal @Willyham @ross-  @orbiteleven 
