### PR TITLE
Non-controversial new eslint 0.24.0 rules and cleanup up formatting

### DIFF
--- a/rc/.eslintrc.es6.json
+++ b/rc/.eslintrc.es6.json
@@ -1,43 +1,20 @@
 {
     "rules": {
-        "no-catch-shadow": 2,
         "no-continue": 2,
-        "no-div-regex": 2,
-        "no-else-return": 2,
-        "no-eq-null": 2,
-        "no-extra-parens": 2,
-        "no-inline-comments": 2,
-        "no-mixed-requires": 2,
         "no-this-before-super": 2,
-        "no-throw-literal": 2,
-        "no-unexpected-multiline": 2,
-        "no-unneeded-ternary": 2,
         "newline-after-var": [
             2,
             "always"
         ],
         "no-var": 2,
         "prefer-const": 2,
-        "array-bracket-spacing": [
-            2,
-            "never"
-        ],
         "accessor-pairs": [
             2,
             {
                 "getWithoutSet": true
             }
         ],
-        "block-scoped-var": 2,
-        "computed-property-spacing": [
-            2,
-            "never"
-        ],
-        "constructor-super": 0,
-        "dot-location": [
-            2,
-            "property"
-        ],
+        "constructor-super": 2,
         "func-style": [
             2,
             "declaration"
@@ -69,27 +46,15 @@
             15
         ],
         "newline-after-var": 2,
-        "object-curly-spacing": [
-            2,
-            "never"
-        ],
         "object-shorthand": [
             2,
             "always"
-        ],
-        "operator-linebreak": [
-            2,
-            "after"
         ],
         "quote-props": [
             2,
             "as-needed"
         ],
         "sort-vars": 2,
-        "space-before-function-paren": [
-            2,
-            "never"
-        ],
         "spaced-comment": [
             2,
             [

--- a/rc/.eslintrc.json
+++ b/rc/.eslintrc.json
@@ -25,7 +25,7 @@
         "no-cond-assign": 2,
         "no-console": 2,
         "no-constant-condition": 2,
-        "no-continue": 2,
+        "no-continue": 0,
         "no-control-regex": 2,
         "no-debugger": 2,
         "no-delete-var": 2,
@@ -117,7 +117,6 @@
         "no-sync": 0,
         "no-ternary": 0,
         "no-trailing-spaces": 2,
-        "no-this-before-super": 2,
         "no-throw-literal": 2,
         "no-try-catch": 2,
         "no-undef": 2,
@@ -269,7 +268,7 @@
         "newline-after-var": 0,
         "object-curly-spacing": [
             2,
-            "never"
+            "always"
         ],
         "object-shorthand": 0,
         "one-var": [
@@ -314,7 +313,7 @@
         ],
         "space-before-function-paren": [
             2,
-            "always"
+            "never"
         ],
         "space-in-brackets": [
             2,

--- a/rc/.eslintrc.json
+++ b/rc/.eslintrc.json
@@ -20,38 +20,38 @@
         "no-array-constructor": 2,
         "no-bitwise": 0,
         "no-caller": 2,
-        "no-catch-shadow": 0,
+        "no-catch-shadow": 2,
         "no-comma-dangle": 2,
         "no-cond-assign": 2,
         "no-console": 2,
         "no-constant-condition": 2,
-        "no-continue": 0,
+        "no-continue": 2,
         "no-control-regex": 2,
         "no-debugger": 2,
         "no-delete-var": 2,
-        "no-div-regex": 0,
+        "no-div-regex": 2,
         "no-dupe-keys": 2,
         "no-dupe-args": 2,
         "no-duplicate-case": 2,
-        "no-else-return": 0,
+        "no-else-return": 2,
         "no-empty": 2,
         "no-empty-class": 2,
         "no-empty-character-class": 2,
         "no-empty-label": 2,
-        "no-eq-null": 0,
+        "no-eq-null": 2,
         "no-eval": 2,
         "no-ex-assign": 2,
         "no-extend-native": 2,
         "no-extra-bind": 2,
         "no-extra-boolean-cast": 2,
-        "no-extra-parens": 0,
+        "no-extra-parens": 2,
         "no-extra-semi": 2,
         "no-extra-strict": 2,
         "no-fallthrough": 2,
         "no-floating-decimal": 2,
         "no-func-assign": 2,
         "no-implied-eval": 2,
-        "no-inline-comments": 0,
+        "no-inline-comments": 2,
         "no-inner-declarations": [
             2,
             "functions"
@@ -65,14 +65,17 @@
         "no-lonely-if": 2,
         "no-loop-func": 2,
         "no-mixed-requires": [
-            0,
+            2,
             false
         ],
         "no-mixed-spaces-and-tabs": [
             2,
             false
         ],
-        "linebreak-style": [2, "unix"],
+        "linebreak-style": [
+            2,
+            "unix"
+        ],
         "no-multi-spaces": 2,
         "no-multi-str": 2,
         "no-multiple-empty-lines": [
@@ -114,15 +117,15 @@
         "no-sync": 0,
         "no-ternary": 0,
         "no-trailing-spaces": 2,
-        "no-this-before-super": 0,
-        "no-throw-literal": 0,
+        "no-this-before-super": 2,
+        "no-throw-literal": 2,
         "no-try-catch": 2,
         "no-undef": 2,
         "no-undef-init": 2,
         "no-undefined": 0,
-        "no-unexpected-multiline": 0,
+        "no-unexpected-multiline": 2,
         "no-underscore-dangle": 0,
-        "no-unneeded-ternary": 0,
+        "no-unneeded-ternary": 2,
         "no-unreachable": 2,
         "no-unused-expressions": 2,
         "no-unused-vars": [
@@ -153,15 +156,21 @@
         "no-with": 2,
         "no-wrap-func": 2,
 
-        "array-bracket-spacing": [0, "never"],
+        "array-bracket-spacing": [
+            2,
+            "never"
+        ],
         "accessor-pairs": 0,
-        "block-scoped-var": 0,
+        "block-scoped-var": 2,
         "brace-style": [
             2,
             "1tbs"
         ],
         "camelcase": 2,
-        "comma-dangle": [2, "never"],
+        "comma-dangle": [
+            2,
+            "never"
+        ],
         "comma-spacing": [
             2,
             {
@@ -177,7 +186,10 @@
             2,
             11
         ],
-        "computed-property-spacing": [0, "never"],
+        "computed-property-spacing": [
+            2,
+            "never"
+        ],
         "consistent-return": 2,
         "consistent-this": [
             2,
@@ -189,8 +201,16 @@
             "all"
         ],
         "default-case": 2,
-        "dot-location": 0,
-        "dot-notation": [2, { "allowKeywords": true }],
+        "dot-location": [
+            2,
+            "property"
+        ],
+        "dot-notation": [
+            2,
+            {
+                "allowKeywords": true
+            }
+        ],
         "eol-last": 2,
         "eqeqeq": 2,
         "func-names": 2,
@@ -247,14 +267,20 @@
         ],
         "new-parens": 2,
         "newline-after-var": 0,
-        "object-curly-spacing": [0, "never"],
+        "object-curly-spacing": [
+            2,
+            "never"
+        ],
         "object-shorthand": 0,
-        "one-var": [2, "never"],
+        "one-var": [
+            2,
+            "never"
+        ],
         "operator-assignment": [
             0,
             "always"
         ],
-        "operator-linebreak": 0,
+        "operator-linebreak": 2,
         "padded-blocks": 0,
         "quote-props": 0,
         "quotes": [
@@ -263,7 +289,13 @@
         ],
         "radix": 2,
         "semi": 2,
-        "semi-spacing": [2, {"before": false, "after": true}],
+        "semi-spacing": [
+            2,
+            {
+                "before": false,
+                "after": true
+            }
+        ],
         "sort-vars": 0,
         "space-after-function-name": [
             2,
@@ -277,7 +309,10 @@
             2,
             "always"
         ],
-        "space-before-function-paren": [0, "always"],
+        "space-before-function-paren": [
+            2,
+            "always"
+        ],
         "space-in-brackets": [
             2,
             "never"

--- a/rc/.eslintrc.json
+++ b/rc/.eslintrc.json
@@ -280,7 +280,10 @@
             0,
             "always"
         ],
-        "operator-linebreak": 2,
+        "operator-linebreak": [
+            2,
+            "after"
+        ],
         "padded-blocks": 0,
         "quote-props": 0,
         "quotes": [


### PR DESCRIPTION
This PR adds most of the new rules in eslint 0.24.0 that are non-controversial or were already enforced in lint-trap but missing in uber/standard. A separate PR will be submitted for those rules that are deemed more controversial.

Rules that are now turned on:
- [`no-catch-shadow`](https://github.com/eslint/eslint/blob/master/docs/rules/no-catch-shadow.md)
- [`no-continue`](https://github.com/eslint/eslint/blob/master/docs/rules/no-continue.md)
- [`no-div-regex`](https://github.com/eslint/eslint/blob/master/docs/rules/no-div-regex.md)
- [`no-else-return`](https://github.com/eslint/eslint/blob/master/docs/rules/no-else-return.md)
- [`no-eq-null`](https://github.com/eslint/eslint/blob/master/docs/rules/no-eq-null.md) (probably a noop since we have strict equality required)
- [`no-extra-parens`](https://github.com/eslint/eslint/blob/master/docs/rules/no-extra-parens.md)
- [`no-inline-comments`](https://github.com/eslint/eslint/blob/master/docs/rules/no-inline-comments.md) (already in lint-trap)
- [`no-mixed-requires`](https://github.com/eslint/eslint/blob/master/docs/rules/no-mixed-requires.md) (probably a noop since we require one var per line)
- [`no-throw-literal`](https://github.com/eslint/eslint/blob/master/docs/rules/no-throw-literal.md)
- [`no-unexpected-multiline`](https://github.com/eslint/eslint/blob/master/docs/rules/no-unexpected-multiline.md)
- [`no-unneeded-ternary`](https://github.com/eslint/eslint/blob/master/docs/rules/no-unneeded-ternary.md)
- [`array-bracket-spacing`](https://github.com/eslint/eslint/blob/master/docs/rules/array-bracket-spacing.md) (was already in lint-trap)
- [`block-scoped-var`](https://github.com/eslint/eslint/blob/master/docs/rules/block-scoped-var.md)
- [`computed-property-spacing`](https://github.com/eslint/eslint/blob/master/docs/rules/computed-property-spacing.md)
- [`dot-location`](https://github.com/eslint/eslint/blob/master/docs/rules/dot-location.md) (dot on property which is the most common style I've seen)
- [`newline-after-var`](https://github.com/eslint/eslint/blob/master/docs/rules/newline-after-var.md)
- [`object-curly-spacing`](https://github.com/eslint/eslint/blob/master/docs/rules/object-curly-spacing.md) (was already in lint-trap)
- [`operator-linebreak`](https://github.com/eslint/eslint/blob/master/docs/rules/operator-linebreak.md) (linebreaks go after infix operators)
- [`space-before-function-paren`](https://github.com/eslint/eslint/blob/master/docs/rules/space-before-function-paren.md)

@Raynos @lxe @mlmorg @johnmegahan @jcorbin @kriskowal 
