### PR TITLE
change indent to 2

### DIFF
--- a/rc/.eslintrc.json
+++ b/rc/.eslintrc.json
@@ -208,7 +208,7 @@
             2,
             "^(err|error|anySpecificError)$"
         ],
-        "indent": [2, 4],
+        "indent": [2, 2],
         "key-spacing": [
             2,
             {


### PR DESCRIPTION
It looks like this is the typical configuration. Users can then copy this to
.eslintrc without worrying about having conflicting configurations.

I was having an issue where uber-standard was picking up my local `~/.eslintrc` which was taken from this repository, however, the indent is always overridden to `[2,2]` in the [index.js](https://github.com/uber/standard/blob/master/index.js#L38).

I'm not even sure `[2, 4]` is a sane configuration. It requires 4-space indent in functions but 2-space indents otherwise.
