### PR TITLE
Revert object-curly-spacing changes

### DIFF
--- a/rc/.eslintrc.json
+++ b/rc/.eslintrc.json
@@ -268,7 +268,7 @@
         "newline-after-var": 0,
         "object-curly-spacing": [
             2,
-            "always"
+            "never"
         ],
         "object-shorthand": 0,
         "one-var": [


### PR DESCRIPTION
In lint-trap and standard (< v4), spacing bracket spacing was disallowed. In v4, it is now the opposite and causes errors in all existing applications. Assuming this is simply a bug, I am reverting that change in this PR.

@malandrew @Raynos 
