### PR TITLE
Added --babel option, restrict no-extra-parens to functions only

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -19,6 +19,7 @@ var argv = minimist(process.argv.slice(2), {
   },
   boolean: [
     'es6',
+    'babel',
     'format',
     'help',
     'stdin',
@@ -86,8 +87,11 @@ if (argv.reporter) {
 var lintOpts = {}
 if (argv['line-length'])
   lintOpts['line-length'] = parseInt(argv['line-length'], 10)
-if (argv.es6)
+if (argv.es6) {
   lintOpts.es6 = true
+} else if (argv.babel) {
+  lintOpts.babel = true
+}
 
 if (argv.stdin) {
   editorConfigGetIndent(process.cwd(), function (err, indent) {

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ var parallel = require('run-parallel')
 var path = require('path')
 var uniq = require('uniq')
 var cloneDeep = require('clone-deep')
+var deepExtend = require('deep-extend')
 
 var DEFAULT_PATTERNS = [
   '**/*.js'
@@ -25,6 +26,7 @@ var DEFAULT_IGNORE_PATTERNS = [
 ]
 
 var es6Config = require(path.join(__dirname, 'rc', '.eslintrc.es6.json'))
+var babelConfig = require(path.join(__dirname, 'rc', '.eslintrc.babel.json'))
 
 var ESLINT_CONFIG = {
   baseConfig: require(path.join(__dirname, 'rc', '.eslintrc.json')),
@@ -42,11 +44,9 @@ function configure(opts) {
   }
 
   if (opts.es6) {
-    config.baseConfig.ecmaFeatures = es6Config.ecmaFeatures
-
-    Object.keys(es6Config.rules).forEach(function onRule(ruleName) {
-      config.baseConfig.rules[ruleName] = es6Config.rules[ruleName]
-    })
+    deepExtend(config.baseConfig, es6Config)
+  } else if (opts.babel) {
+    deepExtend(config.baseConfig, es6Config, babelConfig)
   }
 
   return config;

--- a/package.json
+++ b/package.json
@@ -16,8 +16,10 @@
     "url": "https://github.com/feross/standard/issues"
   },
   "dependencies": {
+    "babel-eslint": "^4.1.1",
     "clone-deep": "^0.1.1",
     "commondir": "^1.0.1",
+    "deep-extend": "^0.4.0",
     "dezalgo": "^1.0.1",
     "editorconfig-get-indent": "^1.0.0",
     "eslint": "^1.2.1",

--- a/rc/.eslintrc.babel.json
+++ b/rc/.eslintrc.babel.json
@@ -1,0 +1,7 @@
+{
+    "parser": "babel-eslint",
+    "ecmaFeatures": {
+        "experimentalObjectRestSpread": true,
+        "jsx": true
+    }
+}

--- a/rc/.eslintrc.es6.json
+++ b/rc/.eslintrc.es6.json
@@ -5,10 +5,6 @@
         "no-continue": 2,
         "no-dupe-class-members": 2,
         "no-this-before-super": 2,
-        "newline-after-var": [
-            2,
-            "always"
-        ],
         "no-var": 2,
         "prefer-arrow-callback": 0,
         "prefer-const": 2,

--- a/rc/.eslintrc.es6.json
+++ b/rc/.eslintrc.es6.json
@@ -54,7 +54,6 @@
             2,
             15
         ],
-        "newline-after-var": 2,
         "object-shorthand": [
             2,
             "always"

--- a/rc/.eslintrc.json
+++ b/rc/.eslintrc.json
@@ -42,7 +42,7 @@
         "no-extend-native": 2,
         "no-extra-bind": 2,
         "no-extra-boolean-cast": 2,
-        "no-extra-parens": 2,
+        "no-extra-parens": [2, "functions"],
         "no-extra-semi": 2,
         "no-fallthrough": 2,
         "no-floating-decimal": 2,


### PR DESCRIPTION
The ES6 config extends the base config, and the Babel config extends the ES6 config.

Addresses:
- https://github.com/uber/standard/issues/31
- https://github.com/uber/standard/issues/35
