### PR TITLE
Restrict no-extra-parens to functions only

### DIFF
--- a/rc/.eslintrc.json
+++ b/rc/.eslintrc.json
@@ -42,7 +42,7 @@
         "no-extend-native": 2,
         "no-extra-bind": 2,
         "no-extra-boolean-cast": 2,
-        "no-extra-parens": 2,
+        "no-extra-parens": [2, "functions"],
         "no-extra-semi": 2,
         "no-fallthrough": 2,
         "no-floating-decimal": 2,


### PR DESCRIPTION
Fixes https://github.com/uber/standard/issues/31
