### PR TITLE
Inherit ES5 newline-after-var setting in ES6

### DIFF
--- a/rc/.eslintrc.es6.json
+++ b/rc/.eslintrc.es6.json
@@ -54,7 +54,6 @@
             2,
             15
         ],
-        "newline-after-var": 2,
         "object-shorthand": [
             2,
             "always"


### PR DESCRIPTION
As a result, this rule is relaxed in ES6.
