### PR TITLE
Allow overriding of path for editorconfig

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ function lintText (text, opts, cb) {
   opts = parseOpts(opts)
   cb = dezalgo(cb)
 
-  editorConfigGetIndent(process.cwd(), function (err, indent) {
+  editorConfigGetIndent(opts.cwd, function (err, indent) {
     if (err) return cb(err)
     opts.indent = indent
     var result


### PR DESCRIPTION
@malandrew 

`opts.cwd` is defaulted to `process.cwd()` if omitted. I'd like to be able to change the directory for use in an atom linter plugin.
